### PR TITLE
Document component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "laminas/laminas-paginator-adapter-laminasdb",
-    "description": "",
+    "description": "laminas-db adapters for laminas-paginator",
     "license": "BSD-3-Clause",
     "keywords": [
         "laminas",

--- a/docs/book/v1/db-select.md
+++ b/docs/book/v1/db-select.md
@@ -1,0 +1,169 @@
+# The DbSelect adapter
+
+The `DbSelect` adapter allows you to provide a `Select` statement for pulling a dataset, and optionally a `Select` statement for pulling a count of results, and an optional `Select` statement for providing an overall count of items.
+
+The adapter does **not** fetch all records from the database in order to count them, nor does it run any queries immediately.
+If no `Select` instance was provided for counting results, the adapter manipulates the original `Select` to produce a corresponding `COUNT` query, and uses the new query to get the number of rows.
+While this approach requires an extra round-trip to the database, doing so is still many times faster than fetching an entire result set and using `count()`, especially with large collections of data.
+
+## Creating An Instance
+
+The `DbSelect` constructor has the following signature:
+
+```php
+public function __construct(
+    \Laminas\Db\Sql\Select $select,
+    \Laminas\Db\Adapter\AdapterInterface|\Laminas\Db\Sql\Sql $adapterOrSqlObject,
+    ?\Laminas\Db\ResultSet\ResultSetInterface $resultSetPrototype = null,
+    ?\Laminas\Db\Sql\Select $countSelect = null
+)
+```
+
+The first argument is the `Select` to use when retrieving results to paginate.
+The next argument, `$adapterOrSqlObject`, provides access to the adapter so it can execute the `Select` statement against the actual database.
+The third argument is a specific result set type to use on results returned from the `Select` operation; these allow you to customize the items returned, if desired.
+(See the [laminas-db ResultSet documentation for more details](https://docs.laminas.dev/laminas-db/result-set/).)
+The fourth argument allows you to specify a specific `Select` instance to use to provide a total count of results.
+
+### Using the AdapterPluginManager
+
+By default, when pulling the `Laminas\Paginator\AdapterPluginManager` from the application DI container, it is aware of the `DbSelect` adapter.
+You can retrieve an instance from the plugin manager via its `get()` method, passing any constructor arguments you want to provide via an array as the second argument:
+
+```php
+use Laminas\Paginator\AdapterPluginManager;
+use Laminas\Paginator\Adapter\LaminasDb\DbSelect;
+
+// $container is the PSR-11 container associated with the application.
+$pluginManager = $container->get(AdapterPluginManager::class);
+
+// $select is the laminas-db Select instance for retrieving items
+// $dbAdapter is the laminas-db adapter you want to use
+$adapter = $pluginManager->get(DbSelect::class, [
+    $select,
+    $dbAdapter
+]);
+```
+
+All required arguments to the constructor must be passed in the array, and they will be passed in the same order to the constructor.
+
+## Modifying Result Items
+
+The default `Laminas\Db\ResultSet\ResultSet` used when iterating over items returns each item as an associative array.
+If you wish to filter out specific fields, modify the column names, or return something other than an associative array, you will need to provide a different `Laminas\Db\ResultSet\ResultSetInterface` implementation to the constructor, or extend the adapter and override the `getItems()` method.
+
+### Providing an Alternate ResultSet
+
+You can override the default `ResultSet` implementation by passing an object implementing `Laminas\Db\ResultSet\ResultSetInterface` as the third constructor argument to the `DbSelect` adapter:
+
+```php
+use Laminas\Db\ResultSet\HydratingResultSet;
+use Laminas\Paginator\Adapter\LaminasDb\DbSelect;
+use Laminas\Paginator\Paginator;
+
+// $objectPrototype is an instance of our custom entity
+// $hydrator is a custom hydrator for our entity
+// (implementing Laminas\Hydrator\HydratorInterface)
+$resultSet = new HydratingResultSet($hydrator, $objectPrototype);
+
+// $query is our Select statement
+// $dbAdapter is the laminas-db adapter instance
+$adapter   = new DbSelect($query, $dbAdapter, $resultSet)
+$paginator = new Laminas\Paginator\Paginator($adapter);
+```
+
+Now when we iterate over `$paginator`, we will get instances of our custom entity instead of associative arrays.
+
+### Overriding getItems
+
+If you want to manipulate the results manually, you can extend the adapter and override the `getItems()` method directly.
+The following example demonstrates using an `array_map()` operation on results in order to cast the rows to an object.
+It assumes the class `App\Fuzz` exists, and defines a static method `fromArray()` that will allow casting an array to an `App\Fuzz` instance.
+
+```php
+namespace App;
+
+use Laminas\Paginator\Adapter\LaminasDb\DbSelect;
+
+class FuzzDbSelect extends DbSelect
+{
+    public function getItems($offset, $itemCountPerPage)
+    {
+        return array_map(
+            function (array $row): Fuzz {
+              return Fuzz::fromArray($row);
+            },
+            parent::getItems($offset, $itemCountPerPage)
+        );
+    }
+}
+```
+
+## Counting Total Items
+
+The database adapter will try and build the most efficient query that will execute on pretty much any modern database.
+However, depending on your database or even your own schema setup, there might be more efficient ways to get a rowcount.
+
+There are two approaches for doing this: providing an additional `Select` instance for retrieving a count to the constructor, or overriding the `count()` method.
+
+### Providing a Select for Counting
+
+You can pass an additional `Laminas\Db\Sql\Select` object as the fourth constructor argument to the `DbSelect` adapter to implement a custom count query.
+
+For example, if you keep track of the count of blog posts in a separate table, you could achieve a faster count query with the following setup:
+
+```php
+use Laminas\Db\Sql\Select;
+use Laminas\Paginator\Adapter\LaminasDb\DbSelect;
+use Laminas\Paginator\Paginator;
+
+$countQuery = new Select();
+$countQuery
+    ->from('item_counts')
+    ->columns([DbSelect::ROW_COUNT_COLUMN_NAME => 'post_count']);
+
+// $query is the Select for retrieving items
+// $dbAdapter is the laminas-db adapter
+$adapter   = new DbSelect($query, $dbAdapter, null, $countQuery);
+$paginator = new Paginator($adapter);
+```
+
+This approach will probably not give you a huge performance gain on small collections and/or simple select queries.
+However, with complex queries and large collections, a similar approach could give you a significant performance boost.
+
+### Overriding the Count Method
+
+The following example demonstrates extending the `DbSelect` adapter to override the `count()` method.
+
+```php
+namespace App;
+
+use Laminas\Db\Sql\Select;
+use Laminas\Paginator\Adapter\LaminasDb\DbSelect;
+
+class MyDbSelect extends DbSelect
+{
+    public function count()
+    {
+        if ($this->rowCount) {
+            return $this->rowCount;
+        }
+
+        $select = new Select();
+        $select
+            ->from('item_counts')
+            ->columns(['c'=>'post_count']);
+
+        $statement = $this->sql->prepareStatementForSqlObject($select);
+        $result    = $statement->execute();
+        $row       = $result->current();
+        $this->rowCount = $row['c'];
+
+        return $this->rowCount;
+    }
+}
+
+// $query is the Select for retrieving items
+// $dbAdapter is the laminas-db adapter
+$adapter = new MyDbSelect($query, $dbAdapter);
+```

--- a/docs/book/v1/db-table-gateway.md
+++ b/docs/book/v1/db-table-gateway.md
@@ -1,0 +1,114 @@
+# The DbTableGateway Adapter
+
+The `DbTableGateway` adapter allows you to provide a `Laminas\Db\TableGateway\AbstractTableGateway` extension for the purpose of both pulling a dataset and providing a count of results.
+
+By default, it assumes you want to fetch all items from the table.
+However, the adapter also allows you to provide WHERE, ORDER BY, GROUP BY, and HAVING clauses (via `Laminas\Db\Sql\Predicate` instances) to refine your selection.
+
+The items returned by the adapter will be based on the `Laminas\Db\ResultSet\ResultSetInterface` result set prototype you associate with the table gateway.
+
+## Creating An Instance
+
+The `DbTableGateway` constructor has the following signature:
+
+```php
+public function __construct(
+    \Laminas\Db\TableGateway\AbstractTableGateway $tableGateway,
+    null|string|array|\Closure|\Laminas\Db\Sql\Where $where = null,
+    null|string|array $order = null,
+    null|string|array $group = null,
+    null|string|array|\Closure|\Laminas\Db\Sql\Having $having = null
+) {
+```
+
+The first argument is the `AbstractTableGateway` class extension representing the table you want to fetch results from.
+The second argument represents the WHERE criteria for filtering results; see the [laminas-db Where documentation](https://docs.laminas.dev/laminas-db/sql/#where-having) for details on what is accepted.
+The third argument represents the order in which results should be sorted; see the [laminas-db "order()" documentation](https://docs.laminas.dev/laminas-db/sql/#order) for details.
+The fourth argument represents how results should be grouped; see the [laminas-db Select documentation](https://docs.laminas.dev/laminas-db/sql/#select) for details.
+The fifth argument represents a HAVING clause, which is generally used when grouping records; see the [laminas-db Having documentation](https://docs.laminas.dev/laminas-db/sql/#where-having) for more details.
+
+### Using the AdapterPluginManager
+
+By default, when pulling the `Laminas\Paginator\AdapterPluginManager` from the application DI container, it is aware of the `DbTableGateway` adapter.
+You can retrieve an instance from the plugin manager via its `get()` method, passing any constructor arguments you want to provide via an array as the second argument:
+
+```php
+use Laminas\Paginator\AdapterPluginManager;
+use Laminas\Paginator\Adapter\LaminasDb\DbTableGateway;
+
+// $container is the PSR-11 container associated with the application.
+$pluginManager = $container->get(AdapterPluginManager::class);
+
+// $table is the laminas-db TableGateway instance for retrieving items
+$adapter = $pluginManager->get(DbTableGateway::class, [$table]);
+```
+
+All required arguments to the constructor must be passed in the array, and they will be passed in the same order to the constructor.
+
+## Counting Total Items
+
+The `DbTableGateway` adapter extends the [DbSelect adapter](db-select.md); during instatiation, it retrieves both the base `Laminas\Db\Sql\Sql` instance and composed `Laminas\Db\ResultSet\ResultSetInterface` prototype composed in the table gateway, creates a `Laminas\Db\Sql\Select` instance, and passes all three to the parent constructor.
+The `Select` instance is thus used as the basis for the count operation as well.
+
+Because there is no way to provide an alternate `Select` for counting, you have two options: extend the `DbTableGateway` adapter and override the `count()` method, or create your `Select` instances for fetching items and the count and pass them to the `DbSelect` constructor instead.
+
+### Overriding the Count Method
+
+The following example demonstrates extending the `DbTableGateway` adapter to override the `count()` method.
+
+```php
+namespace App;
+
+use Laminas\Db\Sql\Select;
+use Laminas\Paginator\Adapter\LaminasDb\DbTableGateway;
+
+class MyDbTableGateway extends DbTableGateway
+{
+    public function count()
+    {
+        if ($this->rowCount) {
+            return $this->rowCount;
+        }
+
+        $select = new Select();
+        $select
+            ->from('item_counts')
+            ->columns(['c'=>'post_count']);
+
+        $statement = $this->sql->prepareStatementForSqlObject($select);
+        $result    = $statement->execute();
+        $row       = $result->current();
+        $this->rowCount = $row['c'];
+
+        return $this->rowCount;
+    }
+}
+
+// $tableGateway is the laminas-db TableGateway for retrieving items
+$adapter = new MyDbTableGateway($tableGateway);
+```
+
+### Creating Select Statements to Pass to a DbSelect Adapter
+
+The following demonstrates pulling the `Sql` instance associated with the `TableGateway` instance, using it to create `Select` instances for pulling items and generating a count, and then using all of them together to create a `DbSelect` instance.
+
+```php
+use Laminas\Paginator\Adapter\LaminasDb\DbSelect;
+
+// $tableGateway is the laminas-db TableGateway we want to use
+$sql    = $tableGateway->getSql();
+$select = $sql->select();
+// Manipulate the $select to retrieve the result set you want.
+// ...
+$count = $sql->select();
+// Manipulate the $count to generate the item count you want.
+// ...
+
+// Create the adapter
+$adapter = new DbSelect(
+    $select,
+    $sql,
+    $tableGateway->getResultSetPrototype(),
+    $count
+);
+```

--- a/docs/book/v1/intro.md
+++ b/docs/book/v1/intro.md
@@ -1,3 +1,13 @@
-# laminas-{component}
+# laminas-paginator-adapter-laminasdb
 
-This component provides ...
+This library provides two adapters for [laminas/laminas-paginator](https://docs.laminas.dev/lmainas-paginator):
+
+- `Laminas\Paginator\Adapter\LaminasDb\DbSelect`
+- `Laminas\Paginator\Adapter\LaminasDb\DbTableGateway`
+
+These provide pagination support for [laminas/laminas-db](https://docs.laminas.dev/laminas-db/) SQL select and TableGateway features.
+
+- [DbSelect documentation](db-select.md)
+- [DbTableGateway documentation](db-table-gateway.md)
+
+Each is configured with the `Laminas\Paginator\AdapterPluginManager` when used in laminas-mvc applications, or in applications utilizing config providers, such as Mezzio applications.

--- a/docs/book/v1/intro.md
+++ b/docs/book/v1/intro.md
@@ -1,4 +1,4 @@
-# laminas-paginator-adapter-laminasdb
+# Introduction
 
 This library provides two adapters for [laminas/laminas-paginator](https://docs.laminas.dev/lmainas-paginator):
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,12 +2,18 @@ docs_dir: docs/book
 site_dir: docs/html
 nav:
     - Home: index.md
-    - Introduction: v1/intro.md
-site_name: 'laminas-{component}'
-site_description: ''
-repo_url: 'https://github.com/laminas/laminas-{component}'
+    - v1:
+      - Introduction: v1/intro.md
+      - "DbSelect Adapter": v1/db-select.md
+      - "DbTableGateway Adapter": v1/db-table-gateway.md
+site_name: 'laminas-paginator-adapter-laminasdb'
+site_description: 'laminas-db adapters for laminas-paginator'
+repo_url: 'https://github.com/laminas/laminas-paginator-adapter-laminasdb'
 extra:
     project: Components
     installation:
-        config_provider_class: 'Laminas\{component}\ConfigProvider'
-        module_class: 'Laminas\{component}\Module'
+        config_provider_class: 'Laminas\Paginator\Adapter\LaminasDb\ConfigProvider'
+        module_class: 'Laminas\Paginator\Adapter\LaminasDb\Module'
+    current_version: v1
+    versions:
+      - v1


### PR DESCRIPTION
- Pulls in DbSelect documentation from laminas-paginator and expands it, including a section on the constructor and pulling it from the adapter plugin manager.
- Adds documentation for DbTableGateway adapter.
- Updates mkdocs configuration
