### PR TITLE
Satisfy PHP 8.1 `Countable` Interface

### DIFF
--- a/src/DbSelect.php
+++ b/src/DbSelect.php
@@ -13,7 +13,6 @@ use Laminas\Db\Sql\Sql;
 use Laminas\Paginator\Adapter\AdapterInterface;
 use Laminas\Paginator\Adapter\Exception\MissingRowCountColumnException;
 use Laminas\Paginator\Exception;
-
 use ReturnTypeWillChange;
 
 use function array_key_exists;

--- a/src/DbSelect.php
+++ b/src/DbSelect.php
@@ -14,6 +14,8 @@ use Laminas\Paginator\Adapter\AdapterInterface;
 use Laminas\Paginator\Adapter\Exception\MissingRowCountColumnException;
 use Laminas\Paginator\Exception;
 
+use ReturnTypeWillChange;
+
 use function array_key_exists;
 use function iterator_to_array;
 use function strtolower;
@@ -105,6 +107,7 @@ class DbSelect implements AdapterInterface
      * @return int
      * @throws MissingRowCountColumnException
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         if ($this->rowCount !== null) {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Adding the `ReturnTypeWillChange` attribute to the DbSelect::count() method to satisfy the PHP 8.1 `Countable` interface.  
This caused the CS checks to fail as well as rendering `"Deprecated: Return type of Test::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in [...]"`.

I hope I've correctly followed the contribution guide :eyes: 