### PR TITLE
Archive and abandon `laminas-paginator-adapter-laminasdb`

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,0 @@
-coverage_clover: clover.xml
-json_path: coveralls-upload.json

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # laminas-paginator-adapter-laminasdb
 
-[![Build Status](https://github.com/laminas/laminas-paginator-adapter-laminasdb/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/laminas/laminas-paginator-adapter-laminasdb/actions/workflows/continuous-integration.yml)
-[![type-coverage](https://shepherd.dev/github/laminas/laminas-paginator-adapter-laminasdb/coverage.svg)](https://shepherd.dev/github/laminas/laminas-paginator-adapter-laminasdb)
-[![Psalm level](https://shepherd.dev/github/laminas/laminas-paginator-adapter-laminasdb/level.svg)](https://shepherd.dev/github/laminas/laminas-paginator-adapter-laminasdb)
+> [!CAUTION]
+> This package is **abandoned** and will receive no further development.
+>
+> See the Technical Steering Committee [meeting minutes](https://github.com/laminas/technical-steering-committee/blob/main/meetings/minutes/2024-11-04-TSC-Minutes.md#archive--abandon-various-legacy-libraries).
 
 > ## 🇷🇺 Русским гражданам
 >
@@ -38,8 +39,3 @@ $ composer require laminas/laminas-paginator-adapter-laminasdb
 ## Documentation
 
 Browse the documentation online at https://docs.laminas.dev/laminas-paginator-adapter-laminasdb/
-
-## Support
-
-- [Issues](https://github.com/laminas/laminas-paginator-adapter-laminasdb/issues/)
-- [Forum](https://discourse.laminas.dev/)

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "rss": "https://github.com/laminas/laminas-laminas-paginator-adapter-db/releases.atom",
         "forum": "https://discourse.laminas.dev/"
     },
+    "abandoned": true,
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "laminas/laminas-db": "^2.13.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4160,11 +4160,11 @@
             "type": "project",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.x-dev",
-                    "dev-4.x": "4.x-dev",
-                    "dev-3.x": "3.x-dev",
+                    "dev-1.x": "1.x-dev",
                     "dev-2.x": "2.x-dev",
-                    "dev-1.x": "1.x-dev"
+                    "dev-3.x": "3.x-dev",
+                    "dev-4.x": "4.x-dev",
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {

--- a/docs/book/v1/intro.md
+++ b/docs/book/v1/intro.md
@@ -1,6 +1,6 @@
 # Introduction
 
-This library provides two adapters for [laminas/laminas-paginator](https://docs.laminas.dev/lmainas-paginator):
+This library provides two adapters for [laminas/laminas-paginator](https://docs.laminas.dev/laminas-paginator):
 
 - `Laminas\Paginator\Adapter\LaminasDb\DbSelect`
 - `Laminas\Paginator\Adapter\LaminasDb\DbTableGateway`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,7 @@ nav:
       - Introduction: v1/intro.md
       - "DbSelect Adapter": v1/db-select.md
       - "DbTableGateway Adapter": v1/db-table-gateway.md
-site_name: 'laminas-paginator-adapter-laminasdb'
+site_name: 'laminas-paginator-adapter-laminasdb (Abandoned)'
 site_description: 'laminas-db adapters for laminas-paginator'
 repo_url: 'https://github.com/laminas/laminas-paginator-adapter-laminasdb'
 extra:

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "local>laminas/.github:renovate-config"
-  ]
-}


### PR DESCRIPTION
> [!CAUTION]
> This package is **abandoned** and will receive no further development.
>
> See the Technical Steering Committee [meeting minutes](https://github.com/laminas/technical-steering-committee/blob/main/meetings/minutes/2024-11-04-TSC-Minutes.md#archive--abandon-various-legacy-libraries).
